### PR TITLE
change devtools to remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # itdepends
 
 <!-- badges: start -->
-![![Travis build status](https://travis-ci.org/jimhester/itdepends.svg?branch=master)](https://travis-ci.org/jimhester/itdepends)
+[![Travis build status](https://travis-ci.org/jimhester/itdepends.svg?branch=master)](https://travis-ci.org/jimhester/itdepends)
 <!-- badges: end -->
 
 itdepends provides tools to assess usage, measure weights, visualize

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # itdepends
 
 <!-- badges: start -->
-[![Travis build status](https://travis-ci.org/jimhester/itdepends.svg?branch=master)](https://travis-ci.org/jimhester/itdepends)
+![![Travis build status](https://travis-ci.org/jimhester/itdepends.svg?branch=master)](https://travis-ci.org/jimhester/itdepends)
 <!-- badges: end -->
 
 itdepends provides tools to assess usage, measure weights, visualize
@@ -9,11 +9,11 @@ proportions and assist removal of dependencies.
 
 ## Installation
 
-You can install the development version of itdepends with the [devtools](https://http://devtools.r-lib.org) package.
+You can install the development version of itdepends with the [remotes](https://remotes.r-lib.org) package.
 
 ``` r
-# install.packages("devtools")
-devtools::install_github("jimhester/itdepends")
+# install.packages("remotes")
+remotes::install_github("jimhester/itdepends")
 ```
 
 ## Thanks


### PR DESCRIPTION
Devtools imports pkgload, which imports rprojroot. When rprojroot updates, this will cause an ungraceful installation failure as R tries to install a loaded package. Using remotes::install_github() is safer.